### PR TITLE
Fix Faraday connection

### DIFF
--- a/lib/cloud_pay/client.rb
+++ b/lib/cloud_pay/client.rb
@@ -17,7 +17,7 @@ module CloudPay
     def perform_request(path, params, options = {})
       idempotency_key = options[:idempotency_key]
 
-      connection.basic_auth(config.public_key, config.secret_key)
+      connection.request(:authorization, :basic, config.public_key, config.secret_key)
       response = connection.post(path, (params ? convert_to_json(params) : nil), headers(idempotency_key))
 
       Response.new(response.status, response.body, response.headers).tap do |response|


### PR DESCRIPTION
Since Faraday 2.x auth option has been changed and raises error. This pull fixed it.

See [changes](https://github.com/lostisland/faraday/pull/1306/files#diff-970a55ea820b7edafb7eb16195c4358ad2eddafd2b90f3c9cc512a97394ea3a7R32).

Thanks for you work!